### PR TITLE
no longer need to remove go 1.17

### DIFF
--- a/.github/workflows/update-draft-tap.yml
+++ b/.github/workflows/update-draft-tap.yml
@@ -15,7 +15,6 @@ jobs:
           ./create_formula.sh
       - name: Validate Formula
         run: |
-          brew remove go@1.17
           brew install --build-from-source ./Formula/draft.rb
       - name: Add & Commit
         uses: EndBug/add-and-commit@v9.1.1


### PR DESCRIPTION
the go@1.17 brew formula is no longer default installed on the runner, so we can remove the step that uninstalls it