### PR TITLE
allow contents write permission to allow tap to update formula

### DIFF
--- a/.github/workflows/update-draft-tap.yml
+++ b/.github/workflows/update-draft-tap.yml
@@ -12,7 +12,7 @@ jobs:
   update-tap:
     runs-on: macos-13
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - name: Harden Runner


### PR DESCRIPTION
the current workflows are failing after changes to the org default token permissions, so we need to grant contents:read permissions so that the tap can be updated by this workflow