### PR TITLE
remove deprecated vendor make alias

### DIFF
--- a/.github/workflows/update-draft-tap.yml
+++ b/.github/workflows/update-draft-tap.yml
@@ -41,7 +41,7 @@ jobs:
           brew --version
       - name: Validate Formula
         run: |
-          brew install --verbose $(pwd)/Formula/draft.rb
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose $(pwd)/Formula/draft.rb
       - name: Create Pull Request
         if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/update-draft-tap.yml
+++ b/.github/workflows/update-draft-tap.yml
@@ -41,7 +41,7 @@ jobs:
           brew --version
       - name: Validate Formula
         run: |
-          brew install --verbose ./Formula/draft.rb
+          brew install --verbose $(pwd)/Formula/draft.rb
       - name: Create Pull Request
         if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/update-draft-tap.yml
+++ b/.github/workflows/update-draft-tap.yml
@@ -41,7 +41,7 @@ jobs:
           brew --version
       - name: Validate Formula
         run: |
-          HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose $(pwd)/Formula/draft.rb
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew install --formula --build-from-source --verbose $(pwd)/Formula/draft.rb
       - name: Create Pull Request
         if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v6

--- a/Formula/draft.rb
+++ b/Formula/draft.rb
@@ -11,8 +11,6 @@ class Draft < Formula
   def install
     ENV.deparallelize
     system "GO11MODULE=on"
-    system "make", "go-generate"
-    system "make", "vendor"
     system "go", "build","-v","-ldflags","-X github.com/Azure/draft/cmd.VERSION=%s" % [version],"-o","."
     system "mkdir","#{prefix}/bin"
     system "cp", "draft", "#{prefix}/bin/draft"

--- a/create_formula.sh
+++ b/create_formula.sh
@@ -73,7 +73,6 @@ echo """class Draft < Formula
   def install
     ENV.deparallelize
     system \"GO11MODULE=on\"
-    system \"make\", \"go-generate\"
     system \"go\", \"build\",\"-v\",\"-ldflags\",\"-X github.com/Azure/draft/cmd.VERSION=%s\" % [version],\"-o\",\".\"
     system \"mkdir\",\"#{prefix}/bin\"
     system \"cp\", \"draft\", \"#{prefix}/bin/draft\"


### PR DESCRIPTION
we don't vendor this repo, and the generation is handled with reusable workflows now, so we don't need either part to build