### PR TITLE
deprecate tap for hombrew core

### DIFF
--- a/.github/workflows/update-draft-tap.yml
+++ b/.github/workflows/update-draft-tap.yml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [master]
-  schedule:
-    - cron: "0 0 * * *"
 permissions:
   contents: write
   pull-requests: write

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Draft Homebrew Repository
+# (Deprecated) Draft Homebrew Repository
+
+## This repo is deprecated as the homebrew-core [includes draft](https://github.com/Homebrew/homebrew-core/pull/198839)
 
 This is a homebrew repo for installing [Draft](https://github.com/Azure/draft).
 


### PR DESCRIPTION
the homebrew core repo has draft now, so we can deprecate this repo

https://github.com/Homebrew/homebrew-core/pull/198839